### PR TITLE
Fix calendar packages versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "jquery-ui-timepicker-addon": "^1.5.5",
     "leaflet": "^0.7.7",
     "moment": "^2.13.0",
-    "primeng": "^1.0.0-beta.11",
-    "primeui": "^4.1.14",
+    "primeng": "1.0.0-beta.12",
+    "primeui": "4.1.14",
     "rxjs": "5.0.0-beta.6",
     "tether": "^1.3.3",
     "zone.js": "~0.6.12"


### PR DESCRIPTION
Some of the dependencies was automatically updated and this caused the broken build. I have fixed the package versions tightly.